### PR TITLE
Wee refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ a) Patches need to be declared in the `extra` config area of Composer (root pack
 ```
 A patch's _group_ and _name_ will create its ID, used internally (i.e. `patch-group-1/patch-name-1`), so make sure you follow these 2 rules:
 - `patch-group-1` MUST be unique in the `patches` object literal
-- `patch-name-1` MUST be unique in its patch group
+- `patch-name-1` MUST be unique in its patch _group_
+
 Examples of patch groups: "magento", "drupal", "security".
 Examples of patch names: "CVS-1", "composer-autoloader".
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,28 @@ The patching is idempotent as much as the `patch` tool is, meaning patches will 
 
 a) Patches need to be declared in the `extra` config area of Composer (root package only):
 ```json
-  "extra": {
-    "patches": {
-        "magento": {
-          "autoloader-patch": {
-              "name": "Autoloader-patcher",
-              "title": "Allow composer autoloader to be applied to Mage.php",
-              "url": "https://raw.githubusercontent.com/inviqa/magento-patches/magento-composer-autoloader-patch/composer-autoloader/0001-Adding-Composer-autoloader-to-Mage.patch?token=token"
-          }
+    "extra": {
+        "patches": {
+            "patch-group-1": {
+                "patch-name-1": {
+                    "title": "Allow composer autoloader to be applied to Mage.php",
+                    "url": "https://url/to/file1.patch"
+                }
+            },
+            "patch-group-2": {
+                "patch-name-1": {
+                    "title": "Fixes Windows 8.1",
+                    "url": "https://url/to/file2.patch"
+                }
+            }        
         }
-      }
-  }
+    }
 ```
+A patch's _group_ and _name_ will create its ID, used internally (i.e. `patch-group-1/patch-name-1`), so make sure you follow these 2 rules:
+- `patch-group-1` MUST be unique in the `patches` object literal
+- `patch-name-1` MUST be unique in its patch group
+Examples of patch groups: "magento", "drupal", "security".
+Examples of patch names: "CVS-1", "composer-autoloader".
 
 b) Additional scripts callbacks need to be added for automatic patching on `install` or `update` (root package only):
 ```json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Patcher
 Applying generic patches using the `patch` tool using Composer's `script` feature.  
-The patching is idempotent as much as the `patch` tool is, meaning patches will _not_ be applied if `patch` decides not to.
+The patching is idempotent as much as the `patch` tool is, meaning patches will _not_ be re-applied if `patch` decides not to.
 
 ## Project setup
 

--- a/src/Inviqa/Patcher.php
+++ b/src/Inviqa/Patcher.php
@@ -6,6 +6,7 @@ use Inviqa\Downloader\Composer as composerDownloader;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use \Symfony\Component\Process\ProcessUtils;
 
 class Patcher
 {
@@ -14,42 +15,51 @@ class Patcher
     /** @var ConsoleOutput */
     private $output;
 
+    /** @var \Composer\Script\Event  */
+    private $event;
+
     public function patch(\Composer\Script\Event $event)
     {
         $this->output = new ConsoleOutput();
+        $this->event  = $event;
 
-        $extra = $event->getComposer()->getPackage()->getExtra();
-
-        foreach ($extra['patches']['magento'] as $option) {
-            $this->output->writeln("<info>Downloading patch: " . $option['name'] . "</info>");
-            $downloader = new composerDownloader();
-            $this->patchFiles[] = $downloader->getContents($option['url'], $option['name']);
-        }
-
-        $this->applyPatch();
+        $this->fetchPatches();
+        $this->applyPatches();
     }
 
-    private function applyPatch()
+    private function fetchPatches()
     {
-        $this->output->writeln("<info>Applying Patch</info>");
+        $downloader = new composerDownloader();
+        $extra = $this->event->getComposer()->getPackage()->getExtra();
 
-        foreach ($this->patchFiles as $filesToPatch)
-        {
+        foreach ($extra['patches'] as $patchGroupName => $patchGroup) {
+            foreach ($patchGroup as $patchInfo) {
+                $patchNamespace = $patchGroupName . '/' . $patchInfo['name'];
+                $this->output->writeln("<info>Fetching patch $patchNamespace</info>");
+                $patchContent = $downloader->getContents($patchInfo['url'], $patchInfo['name']);
+                $this->patchFiles[$patchNamespace] = $patchContent;
+            }
+        }
+    }
+
+    private function applyPatches()
+    {
+        $this->output->writeln("<info>Applying patches...</info>");
+
+        foreach ($this->patchFiles as $patchNamespace => $filesToPatch) {
             if (!$this->canApplyPatch($filesToPatch)) {
                 $this->output->writeln('<comment>Patch skipped. Patch was already applied?</comment>');
                 continue;
             }
 
-            $process = new Process("patch -p 1 < " . $filesToPatch);
+            $process = new Process("patch -p 1 < " . ProcessUtils::escapeArgument($filesToPatch));
             try {
                 $process->mustRun();
-
-                echo $process->getOutput();
-            } catch (ProcessFailedException $e) {
-                echo $e->getMessage();
+                $this->output->writeln("<info>Patch $patchNamespace successfully applied.</info>");
+            } catch (\Exception $e) {
+                $this->output->getErrorOutput()->writeln("<error>Error applying patch $patchNamespace:</error>");
+                $this->output->getErrorOutput()->writeln("<error>{$e->getMessage()}</error>");
             }
-
-            $this->output->writeln("<info>File successfully patched.</info>");
         }
     }
 
@@ -59,7 +69,7 @@ class Patcher
      */
     private function canApplyPatch($filesToPatch)
     {
-        $process = new Process("patch --dry-run -p 1 < " . $filesToPatch);
+        $process = new Process("patch --dry-run -p 1 < " . ProcessUtils::escapeArgument($filesToPatch));
         try {
             $process->mustRun();
             return $process->getExitCode() === 0;

--- a/src/Inviqa/Patcher.php
+++ b/src/Inviqa/Patcher.php
@@ -33,10 +33,10 @@ class Patcher
         $extra = $this->event->getComposer()->getPackage()->getExtra();
 
         foreach ($extra['patches'] as $patchGroupName => $patchGroup) {
-            foreach ($patchGroup as $patchInfo) {
-                $patchNamespace = $patchGroupName . '/' . $patchInfo['name'];
+            foreach ($patchGroup as $patchName => $patchInfo) {
+                $patchNamespace = $patchGroupName . '/' . $patchName;
                 $this->output->writeln("<info>Fetching patch $patchNamespace</info>");
-                $patchContent = $downloader->getContents($patchInfo['url'], $patchInfo['name']);
+                $patchContent = $downloader->getContents($patchInfo['url'], $patchGroupName . '_' . $patchName);
                 $this->patchFiles[$patchNamespace] = $patchContent;
             }
         }


### PR DESCRIPTION
- escape shell args
- display nicer and explicit messages
- remove the hardcoded "magento" patch key and convert into generic patch _groups_
- remove the redundant "name" key of each patch. the key will be used instead

Fixes https://github.com/jamescowie/composer-patcher/issues/2
