### PR TITLE
Change required symfony value in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-      "symfony/console": "2.6.*",
+      "symfony/console": "^2.6.0",
       "symfony/process": "*"
     },
     "autoload": {


### PR DESCRIPTION
Resolves #10

Alter the symfony/console requirement to allow any version of symfony/console above 2.6.; resolves Magento 2.2.5 compatibility issue.